### PR TITLE
Added string replace line to fix implementation error.

### DIFF
--- a/snowflake-connector/src/jwt.rs
+++ b/snowflake-connector/src/jwt.rs
@@ -17,6 +17,7 @@ pub fn create_token<P: AsRef<Path>>(
     for _ in 0..padding {
         public_key_fingerprint.push('=');
     }
+    let public_key_fingerprint = public_key_fingerprint.replace('_',"/"); //Snowflake expects "/" and not "_"
     let qualified_username  = format!("{account_identifier}.{user}");
     let issuer = format!("{qualified_username}.SHA256:{public_key_fingerprint}");
     let claims = Claims::create(Duration::from_hours(1))


### PR DESCRIPTION
I was having an issue where Snowflake was not accepting the JWT because it expects the fingerprint to be formatted with "/" instead of "_".

for example => "p0T8x62Z4CX2_sQPeLX7brvOM6sK2j5ICVq_0vmQJY0o=" should be "p0T8x62Z4CX2**/**sQPeLX7brvOM6sK2j5ICVq**/**0vmQJY0o="