### PR TITLE
Update JWT token creation to use RS256KeyPair

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "snowflake-connector",
     "snowflake-deserializer",

--- a/snowflake-connector/src/jwt.rs
+++ b/snowflake-connector/src/jwt.rs
@@ -1,17 +1,13 @@
-use std::path::Path;
-
 use jwt_simple::prelude::*;
+/// Re-export the `RS256KeyPair` type from `jwt_simple` to ease loading
+pub use jwt_simple::algorithms::RS256KeyPair;
 
-pub fn create_token<P: AsRef<Path>>(
-    public_key_path: P,
-    private_key_path: P,
+pub fn create_token(
+    key_pair: &RS256KeyPair,
     account_identifier: &str,
     user: &str,
 ) -> Result<String, KeyPairError> {
-    let private_key = get_private_key(private_key_path)?;
-    let public_key_fingerprint = get_public_key(public_key_path)?;
-    let mut public_key_fingerprint = RS256PublicKey::from_pem(&public_key_fingerprint)
-        .map_err(KeyPairError::FingerprintGeneration)?
+    let mut public_key_fingerprint = key_pair.public_key()
         .sha256_thumbprint();
     let padding = public_key_fingerprint.len() % 3;
     for _ in 0..padding {
@@ -22,44 +18,16 @@ pub fn create_token<P: AsRef<Path>>(
     let claims = Claims::create(Duration::from_hours(1))
         .with_issuer(issuer)
         .with_subject(qualified_username);
-    let key_pair = RS256KeyPair::from_pem(&private_key)
-        .map_err(KeyPairError::KayPairGeneration)?;
     key_pair.sign(claims)
-        .map_err(KeyPairError::KayPairGeneration)
-}
-
-fn get_private_key<P: AsRef<Path>>(path: P) -> Result<String, KeyPairError> {
-    std::fs::read_to_string(&path)
-        .map_err(|e| {
-            KeyPairError::PrivateKeyRead(e, if let Some(path) = path.as_ref().to_str() {
-                path
-            } else {
-                "N/A"
-            }.into())
-        })
-}
-
-fn get_public_key<P: AsRef<Path>>(path: P) -> Result<String, KeyPairError> {
-    std::fs::read_to_string(&path)
-        .map_err(|e| {
-            KeyPairError::PublicKeyRead(e, if let Some(path) = path.as_ref().to_str() {
-                path
-            } else {
-                "N/A"
-            }.into())
-        })
+        .map_err(KeyPairError::KeyPairGeneration)
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum KeyPairError {
-    #[error("failed to read public key, path: {1}—{0}")]
-    PublicKeyRead(std::io::Error, String),
-    #[error("failed to read private key, path: {1}—{0}")]
-    PrivateKeyRead(std::io::Error, String),
     #[error("failed to generate fingerprint from public key—{0}")]
     FingerprintGeneration(anyhow::Error),
     #[error("failed to generate key pair from private key—{0}")]
-    KayPairGeneration(anyhow::Error),
+    KeyPairGeneration(anyhow::Error),
 }
 
 #[cfg(test)]
@@ -68,16 +36,13 @@ mod tests {
 
     #[test]
     fn verify_jwt() -> Result<(), anyhow::Error> {
-        let public_key_path = "./environment_variables/local/rsa_key.pub";
+        let key = RS256KeyPair::generate(2048)?;
         let token = create_token(
-            public_key_path,
-            "./environment_variables/local/rsa_key.p8",
+            &key,
             "TEST_ACCOUNT",
             "TEST_USER",
         )?;
-        let public_key = get_public_key(public_key_path)?;
-        let public_key = RS256PublicKey::from_pem(&public_key)?;
-        let verified = public_key.verify_token::<JWTClaims<NoCustomClaims>>(&token, None);
+        let verified = key.public_key().verify_token::<JWTClaims<NoCustomClaims>>(&token, None);
         assert!(verified.is_ok());
         Ok(())
     }


### PR DESCRIPTION
In my use case for this library, I can't just store the RSA keys on disk (there are many of them, and they need to be emphemeral, also they become more difficult to effective erase when on disk).

It seems both more safe and on account of types, easier, to just use the key pair type directly.